### PR TITLE
Fix arrow key navigation in search input

### DIFF
--- a/client/src/components/LinkColumns.vue
+++ b/client/src/components/LinkColumns.vue
@@ -189,6 +189,7 @@ const focusSearchBar = () => {
 
 const handleArrowKeys = (event: KeyboardEvent) => {
   if (
+    isSearchInputFocused ||
     isModalOpen() ||
     isDropdownOpen() ||
     event.ctrlKey ||


### PR DESCRIPTION
There was a listener in the LinkColumn.vue file that pointed to a function to change focus to the Link components. The function did not have a safe guard against the Search Box being focused. I added the safe guard to that function and it seems to be working as expected. 