### PR TITLE
Fix arrow key navigation

### DIFF
--- a/client/src/components/LinkColumns.vue
+++ b/client/src/components/LinkColumns.vue
@@ -189,6 +189,7 @@ const focusSearchBar = () => {
 
 const handleArrowKeys = (event: KeyboardEvent) => {
   if (
+    isSearchInputFocused ||
     isModalOpen() ||
     isDropdownOpen() ||
     event.ctrlKey ||

--- a/client/src/components/LinkColumns.vue
+++ b/client/src/components/LinkColumns.vue
@@ -189,7 +189,7 @@ const focusSearchBar = () => {
 
 const handleArrowKeys = (event: KeyboardEvent) => {
   if (
-    isSearchInputFocused ||
+    isSearchInputFocused() ||
     isModalOpen() ||
     isDropdownOpen() ||
     event.ctrlKey ||


### PR DESCRIPTION
There was a listener in the LinkColumns.vue file that pointed to a function that handled arrow key events. The function did not have a safe guard against the search box being focused. I added the safe guard to that function and it seems to be working as intended now. 