### PR TITLE
Sorted links by link.order_index to fix drag and drop issue

### DIFF
--- a/client/src/components/LinkColumns.vue
+++ b/client/src/components/LinkColumns.vue
@@ -86,7 +86,7 @@ watch(
 )
 
 const getLinksByColumnType = (columnType: string) => {
-  return linkStore.links.filter((link) => link.column_type === columnType)
+  return linkStore.links.filter((link) => link.column_type === columnType).sort((a, b) => a.order_index - b.order_index)
 }
 
 const getShortcut = (columnType: string) => {


### PR DESCRIPTION
The links were not being sorted by order_index, making it appear that they were not being sorted even though they were on the back end. It seems to be working as intended now. 