### PR TITLE
Dashboard icons integration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@tailwindcss/vite": "^4.0.1",
         "@types/lodash": "^4.17.15",
         "@unhead/vue": "^1.11.20",
+        "axios": "^1.13.2",
         "fuse.js": "^7.0.0",
         "lodash": "^4.17.21",
         "pinia": "^2.3.1",
@@ -26,16 +27,14 @@
         "@types/jsdom": "^21.1.7",
         "@types/node": "^22.13.5",
         "@vitejs/plugin-vue": "^5.2.1",
-        "@vitejs/plugin-vue-jsx": "^4.1.1",
         "@vue/test-utils": "^2.4.6",
         "@vue/tsconfig": "^0.7.0",
         "cypress": "^14.0.1",
         "jsdom": "^26.0.0",
-        "npm-run-all2": "^7.0.2",
         "oxfmt": "^0.26.0",
         "oxlint": "^1.41.0",
         "start-server-and-test": "^2.0.10",
-        "tailwindcss": "^3.4.17",
+        "tailwindcss": "4",
         "typescript": "~5.7.3",
         "vite": "^6.0.11",
         "vite-plugin-compression": "^0.5.1",
@@ -319,8 +318,6 @@
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
-    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.9-commit.d91dfb5", "", {}, "sha512-8sExkWRK+zVybw3+2/kBkYBFeLnEUWz1fT7BLHplpzmtqkOfTbAQ9gkt4pzwGIIZmg4Qn5US5ACjUBenrhezwQ=="],
-
     "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.55.1", "", { "os": "android", "cpu": "arm" }, "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg=="],
@@ -472,8 +469,6 @@
     "@unhead/vue": ["@unhead/vue@1.11.20", "", { "dependencies": { "@unhead/schema": "1.11.20", "@unhead/shared": "1.11.20", "hookable": "^5.5.3", "unhead": "1.11.20" }, "peerDependencies": { "vue": ">=2.7 || >=3" } }, "sha512-sqQaLbwqY9TvLEGeq8Fd7+F2TIuV3nZ5ihVISHjWpAM3y7DwNWRU7NmT9+yYT+2/jw1Vjwdkv5/HvDnvCLrgmg=="],
 
     "@vitejs/plugin-vue": ["@vitejs/plugin-vue@5.2.4", "", { "peerDependencies": { "vite": "^5.0.0 || ^6.0.0", "vue": "^3.2.25" } }, "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA=="],
-
-    "@vitejs/plugin-vue-jsx": ["@vitejs/plugin-vue-jsx@4.2.0", "", { "dependencies": { "@babel/core": "^7.27.1", "@babel/plugin-transform-typescript": "^7.27.1", "@rolldown/pluginutils": "^1.0.0-beta.9", "@vue/babel-plugin-jsx": "^1.4.0" }, "peerDependencies": { "vite": "^5.0.0 || ^6.0.0", "vue": "^3.0.0" } }, "sha512-DSTrmrdLp+0LDNF77fqrKfx7X0ErRbOcUAgJL/HbSesqQwoUvUQ4uYQqaex+rovqgGcoPqVk+AwUh3v9CuiYIw=="],
 
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
@@ -923,7 +918,7 @@
 
     "js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
 
-    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+    "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
     "jsbn": ["jsbn@0.1.1", "", {}, "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="],
 
@@ -987,7 +982,7 @@
 
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
-    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -1445,9 +1440,11 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
-    "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -1515,7 +1512,7 @@
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
-    "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+    "omega_tab_client/tailwindcss": ["tailwindcss@4.1.18", "", {}, "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw=="],
 
     "pinia/@vue/devtools-api": ["@vue/devtools-api@6.6.4", "", {}, "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g=="],
 
@@ -1524,8 +1521,6 @@
     "slice-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "start-server-and-test/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
-
-    "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 

--- a/client/package.json
+++ b/client/package.json
@@ -22,6 +22,7 @@
     "@tailwindcss/vite": "^4.0.1",
     "@types/lodash": "^4.17.15",
     "@unhead/vue": "^1.11.20",
+    "axios": "^1.13.2",
     "fuse.js": "^7.0.0",
     "lodash": "^4.17.21",
     "pinia": "^2.3.1",

--- a/client/src/components/AddLinkCard.vue
+++ b/client/src/components/AddLinkCard.vue
@@ -96,6 +96,7 @@
                   Clear
                 </TpButton>
               </div>
+              <IconSearchPanel @select="handleIconSelect" />
             </div>
           </div>
         </div>
@@ -142,6 +143,7 @@ import {
   TpButton,
   TpTooltip,
 } from "@/components/ui";
+import IconSearchPanel from "@/components/IconSearchPanel.vue";
 
 const linksStore = useLinksStore();
 const userStore = useUserStore();
@@ -226,6 +228,10 @@ const clearIcon = () => {
   if (fileInputRef.value) {
     fileInputRef.value.value = "";
   }
+};
+
+const handleIconSelect = (url: string) => {
+  formData.value.icon = url;
 };
 
 const validateForm = (): boolean => {

--- a/client/src/components/EditLinkModal.vue
+++ b/client/src/components/EditLinkModal.vue
@@ -70,6 +70,7 @@
                 Clear
               </TpButton>
             </div>
+            <IconSearchPanel @select="handleIconSelect" />
           </div>
         </div>
       </div>
@@ -118,6 +119,7 @@ import {
   TpTooltip,
   TpIcon,
 } from "@/components/ui";
+import IconSearchPanel from "@/components/IconSearchPanel.vue";
 
 const linksStore = useLinksStore();
 const { smAndDown: mobile } = useBreakpoint();
@@ -224,6 +226,10 @@ const clearIcon = () => {
   if (fileInputRef.value) {
     fileInputRef.value.value = "";
   }
+};
+
+const handleIconSelect = (url: string) => {
+  formData.value.icon = url;
 };
 
 const validateForm = (): boolean => {

--- a/client/src/components/IconSearchPanel.vue
+++ b/client/src/components/IconSearchPanel.vue
@@ -1,0 +1,168 @@
+<template>
+  <div class="icon-search-panel">
+    <TpInput
+      v-model="searchQuery"
+      label="Search Dashboard Icons"
+      placeholder="e.g., github, docker, slack..."
+      @input="handleSearchInput"
+    />
+
+    <div v-if="isLoading" class="icon-search-panel__loading">
+      <TpSpinner size="sm" />
+      <span>Searching icons...</span>
+    </div>
+
+    <div v-else-if="error" class="icon-search-panel__error">
+      {{ error }}
+    </div>
+
+    <div v-else-if="icons.length > 0" class="icon-search-panel__grid">
+      <button
+        v-for="icon in icons"
+        :key="icon.name"
+        type="button"
+        class="icon-search-panel__item"
+        :title="icon.name"
+        @click="selectIcon(icon)"
+      >
+        <img :src="icon.png_url" :alt="icon.name" class="icon-search-panel__img" />
+      </button>
+    </div>
+
+    <div v-else-if="searchQuery && hasSearched" class="icon-search-panel__empty">
+      No icons found for "{{ searchQuery }}"
+    </div>
+
+    <div v-else class="icon-search-panel__hint">
+      Search for application icons from dashboardicons.com
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { TpInput, TpSpinner } from "@/components/ui";
+import { API } from "@/constants/api";
+import api from "@/services/api";
+import type { DashboardIcon, IconSearchResponse } from "@/types/DashboardIcon";
+
+const emit = defineEmits<{
+  (e: "select", url: string): void;
+}>();
+
+const searchQuery = ref("");
+const icons = ref<DashboardIcon[]>([]);
+const isLoading = ref(false);
+const error = ref("");
+const hasSearched = ref(false);
+
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+const handleSearchInput = () => {
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+  }
+
+  if (!searchQuery.value.trim()) {
+    icons.value = [];
+    hasSearched.value = false;
+    error.value = "";
+    return;
+  }
+
+  debounceTimer = setTimeout(() => {
+    searchIcons();
+  }, 500);
+};
+
+const searchIcons = async () => {
+  const query = searchQuery.value.trim();
+  if (!query) return;
+
+  isLoading.value = true;
+  error.value = "";
+  hasSearched.value = true;
+
+  try {
+    const response = await api.get<IconSearchResponse>(API.SEARCH_ICONS(query));
+    icons.value = response.data.icons;
+  } catch (err) {
+    console.error("Error searching icons:", err);
+    error.value = "Failed to search icons. Please try again.";
+    icons.value = [];
+  } finally {
+    isLoading.value = false;
+  }
+};
+
+const selectIcon = (icon: DashboardIcon) => {
+  emit("select", icon.png_url);
+};
+</script>
+
+<style scoped>
+.icon-search-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tp-space-2);
+}
+
+.icon-search-panel__loading {
+  display: flex;
+  align-items: center;
+  gap: var(--tp-space-2);
+  color: var(--tp-text-muted);
+  font-size: var(--tp-text-sm);
+  padding: var(--tp-space-2);
+}
+
+.icon-search-panel__error {
+  color: var(--tp-error);
+  font-size: var(--tp-text-sm);
+  padding: var(--tp-space-2);
+}
+
+.icon-search-panel__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(48px, 1fr));
+  gap: var(--tp-space-2);
+  max-height: 160px;
+  overflow-y: auto;
+  padding: var(--tp-space-2);
+  border: var(--tp-border-width) solid var(--tp-border);
+  border-radius: var(--tp-radius-sm);
+  background: var(--tp-bg-secondary);
+}
+
+.icon-search-panel__item {
+  width: 48px;
+  height: 48px;
+  padding: var(--tp-space-1);
+  border: var(--tp-border-width) solid transparent;
+  border-radius: var(--tp-radius-sm);
+  background: var(--tp-bg-primary);
+  cursor: pointer;
+  transition:
+    border-color var(--tp-transition-fast),
+    background-color var(--tp-transition-fast);
+}
+
+.icon-search-panel__item:hover {
+  border-color: var(--tp-accent);
+  background: var(--tp-accent-glow);
+}
+
+.icon-search-panel__img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.icon-search-panel__empty,
+.icon-search-panel__hint {
+  color: var(--tp-text-muted);
+  font-size: var(--tp-text-sm);
+  padding: var(--tp-space-2);
+  text-align: center;
+}
+</style>

--- a/client/src/constants/api.ts
+++ b/client/src/constants/api.ts
@@ -11,6 +11,7 @@ export const API = {
   UPDATE_LINK: `${apiBase}/link`,
   DELETE_LINK: (linkId: string) => `${apiBase}/link/${linkId}`,
   SUGGEST: (query: string) => `${apiBase}/suggest/${query}`,
+  SEARCH_ICONS: (query: string) => `${apiBase}/icons/search/${encodeURIComponent(query)}`,
   FEEDBACK: `${apiBase}/feedback`,
   CREATE_SETTINGS: `${apiBase}/settings`,
   UPDATE_SETTINGS: `${apiBase}/settings`,

--- a/client/src/types/DashboardIcon.ts
+++ b/client/src/types/DashboardIcon.ts
@@ -1,0 +1,8 @@
+export type DashboardIcon = {
+  name: string;
+  png_url: string;
+};
+
+export type IconSearchResponse = {
+  icons: DashboardIcon[];
+};

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "omega-tab"
 version = "0.2.2"
-edition = "2021"
+edition = "2024"
 
 [[bin]]
 name = "OmegaTab"

--- a/server/src/assets.rs
+++ b/server/src/assets.rs
@@ -1,6 +1,6 @@
 use axum::{
     body::Body,
-    http::{header, Request, StatusCode},
+    http::{Request, StatusCode, header},
     response::{IntoResponse, Response},
 };
 use rust_embed::RustEmbed;

--- a/server/src/dashboard_icons.rs
+++ b/server/src/dashboard_icons.rs
@@ -1,0 +1,155 @@
+use anyhow::Result;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::LazyLock;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+
+const METADATA_URL: &str =
+    "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/refs/heads/main/metadata.json";
+const CDN_BASE: &str = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons";
+const CACHE_TTL: Duration = Duration::from_secs(60 * 60); // 1 hour
+const MAX_RESULTS: usize = 20;
+
+// Global cache for metadata
+static METADATA_CACHE: LazyLock<RwLock<Option<CachedMetadata>>> =
+    LazyLock::new(|| RwLock::new(None));
+
+struct CachedMetadata {
+    data: HashMap<String, IconMetadata>,
+    fetched_at: Instant,
+}
+
+pub struct DashboardIcons {
+    client: Client,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DashboardIcon {
+    pub name: String,
+    pub png_url: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IconSearchResponse {
+    pub icons: Vec<DashboardIcon>,
+}
+
+// Struct to deserialize the metadata.json format
+#[derive(Debug, Clone, Deserialize)]
+struct IconMetadata {
+    #[serde(default)]
+    aliases: Vec<String>,
+    #[serde(default)]
+    categories: Vec<String>,
+}
+
+impl DashboardIcons {
+    pub fn new() -> Self {
+        Self {
+            client: Client::new(),
+        }
+    }
+
+    pub async fn search(&self, query: &str) -> Result<IconSearchResponse> {
+        tracing::info!("Searching dashboard icons for query: {}", query);
+
+        let metadata = self.get_metadata().await?;
+        let query_lower = query.to_lowercase();
+
+        let icons: Vec<DashboardIcon> = metadata
+            .into_iter()
+            .filter(|(name, meta)| {
+                // Match against icon name
+                if name.to_lowercase().contains(&query_lower) {
+                    return true;
+                }
+                // Match against aliases
+                if meta
+                    .aliases
+                    .iter()
+                    .any(|alias| alias.to_lowercase().contains(&query_lower))
+                {
+                    return true;
+                }
+                // Match against categories
+                if meta
+                    .categories
+                    .iter()
+                    .any(|cat| cat.to_lowercase().contains(&query_lower))
+                {
+                    return true;
+                }
+                false
+            })
+            .take(MAX_RESULTS)
+            .map(|(name, _)| DashboardIcon {
+                png_url: format!("{}/png/{}.png", CDN_BASE, name),
+                name,
+            })
+            .collect();
+
+        tracing::info!("Found {} icons for query: {}", icons.len(), query);
+        Ok(IconSearchResponse { icons })
+    }
+
+    async fn get_metadata(&self) -> Result<HashMap<String, IconMetadata>> {
+        // Check if we have valid cached data
+        {
+            let cache = METADATA_CACHE.read().await;
+            if let Some(cached) = cache.as_ref() {
+                if cached.fetched_at.elapsed() < CACHE_TTL {
+                    tracing::debug!("Using cached dashboard icons metadata");
+                    return Ok(cached.data.clone());
+                }
+            }
+        }
+
+        // Fetch fresh metadata
+        tracing::info!("Fetching fresh dashboard icons metadata");
+        let metadata = self.fetch_metadata().await?;
+
+        // Update cache
+        {
+            let mut cache = METADATA_CACHE.write().await;
+            *cache = Some(CachedMetadata {
+                data: metadata.clone(),
+                fetched_at: Instant::now(),
+            });
+        }
+
+        Ok(metadata)
+    }
+
+    async fn fetch_metadata(&self) -> Result<HashMap<String, IconMetadata>> {
+        let response = self.client.get(METADATA_URL).send().await?;
+
+        if !response.status().is_success() {
+            tracing::warn!(
+                "Failed to fetch dashboard icons metadata, status: {}",
+                response.status()
+            );
+            return Ok(HashMap::new());
+        }
+
+        let metadata: HashMap<String, IconMetadata> = response.json().await?;
+        Ok(metadata)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    // ensures we can fetch the dashboard icon meta data,
+    // query it, receive icons, and not go over the limit
+    async fn test_dashboard_search() {
+        let dashboard_icons = DashboardIcons::new();
+        let response = dashboard_icons.search("github").await.unwrap();
+        println!("{:?}", response.icons);
+        assert!(!response.icons.is_empty());
+        assert!(response.icons.len() <= MAX_RESULTS);
+    }
+}

--- a/server/src/middleware.rs
+++ b/server/src/middleware.rs
@@ -1,5 +1,5 @@
-use axum::{http::Request, middleware::Next, response::Response};
 use crate::user_jwt;
+use axum::{http::Request, middleware::Next, response::Response};
 
 #[derive(Clone, Debug)]
 pub struct UserContext {
@@ -16,7 +16,10 @@ pub async fn authenticate_user(
     // Skip authentication for public paths
     let public_paths = ["/login", "/register", "/staging_login", "/health"];
     if public_paths.contains(&req.uri().path()) {
-        tracing::debug!("Skipping authentication for public path: {}", req.uri().path());
+        tracing::debug!(
+            "Skipping authentication for public path: {}",
+            req.uri().path()
+        );
         return Ok(next.run(req).await);
     }
 

--- a/server/src/resend.rs
+++ b/server/src/resend.rs
@@ -2,39 +2,38 @@ use resend_rs::types::CreateEmailBaseOptions;
 use resend_rs::{Resend, Result};
 
 pub struct ResendClient {
-  client: Resend,
+    client: Resend,
 }
 
 impl ResendClient {
-  pub fn new() -> Self {
-    tracing::info!("Initializing Resend client");
-    ResendClient {
-      client: Resend::default(),
+    pub fn new() -> Self {
+        tracing::info!("Initializing Resend client");
+        ResendClient {
+            client: Resend::default(),
+        }
     }
-  }
 
-  pub async fn send_email(
-    &self,
-    customer_support_email: &str,
-    subject: &str,
-    email_body: &str,
-  ) -> Result<()> {
-    tracing::info!("Sending email to: {}", customer_support_email);
-    let from = "evan@updates.omega-tab.evanrobertson.dev";
-    let to = [customer_support_email];
+    pub async fn send_email(
+        &self,
+        customer_support_email: &str,
+        subject: &str,
+        email_body: &str,
+    ) -> Result<()> {
+        tracing::info!("Sending email to: {}", customer_support_email);
+        let from = "evan@updates.omega-tab.evanrobertson.dev";
+        let to = [customer_support_email];
 
-    let email = CreateEmailBaseOptions::new(from, to, subject)
-      .with_html(email_body);
+        let email = CreateEmailBaseOptions::new(from, to, subject).with_html(email_body);
 
-    match self.client.emails.send(email).await {
-      Ok(_email) => {
-        tracing::info!("Successfully sent email to: {}", customer_support_email);
-        Ok(())
-      },
-      Err(e) => {
-        tracing::error!("Failed to send email: {:?}", e);
-        Err(e)
-      }
+        match self.client.emails.send(email).await {
+            Ok(_email) => {
+                tracing::info!("Successfully sent email to: {}", customer_support_email);
+                Ok(())
+            }
+            Err(e) => {
+                tracing::error!("Failed to send email: {:?}", e);
+                Err(e)
+            }
+        }
     }
-  }
 }

--- a/server/src/tray.rs
+++ b/server/src/tray.rs
@@ -1,7 +1,7 @@
 use std::sync::mpsc::{self, Receiver};
 use tray_icon::{
-    menu::{Menu, MenuEvent, MenuItem},
     TrayIcon, TrayIconBuilder,
+    menu::{Menu, MenuEvent, MenuItem},
 };
 
 /// Message types that can be sent from the tray
@@ -52,11 +52,13 @@ pub fn create_tray() -> Result<(TrayIcon, Receiver<TrayMessage>), Box<dyn std::e
 
     // Listen for menu events in a separate thread
     let exit_id = exit_item.id().clone();
-    std::thread::spawn(move || loop {
-        if let Ok(event) = MenuEvent::receiver().recv() {
-            if event.id == exit_id {
-                let _ = tx.send(TrayMessage::Exit);
-                break;
+    std::thread::spawn(move || {
+        loop {
+            if let Ok(event) = MenuEvent::receiver().recv() {
+                if event.id == exit_id {
+                    let _ = tx.send(TrayMessage::Exit);
+                    break;
+                }
             }
         }
     });

--- a/server/src/user_jwt.rs
+++ b/server/src/user_jwt.rs
@@ -1,8 +1,8 @@
-use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
-use serde::{Deserialize, Serialize};
-use std::time::{SystemTime, UNIX_EPOCH};
-use std::env;
 use anyhow::Result;
+use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, encode};
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 // Define the JWT claims structure
 #[derive(Debug, Serialize, Deserialize)]
@@ -35,43 +35,43 @@ pub fn generate_jwt(user_id: &str, email: &str) -> Result<String> {
         exp,
         iat,
     };
-    
+
     // Create header
     let header = Header::new(Algorithm::HS256);
-    
+
     // Encode the JWT
     let token = encode(
         &header,
         &claims,
         &EncodingKey::from_secret(secret.as_bytes()),
     )?;
-    
+
     Ok(token)
 }
 
 pub fn validate_jwt(token: &str) -> Result<UserClaims> {
     // Get JWT secret from environment variable
     let secret = env::var("JWT_SECRET").expect("JWT_SECRET must be set");
-    
+
     // Decode and validate the JWT
     let validation = Validation::new(Algorithm::HS256);
-    
+
     let token_data = decode::<UserClaims>(
         token,
         &DecodingKey::from_secret(secret.as_bytes()),
         &validation,
     )?;
-    
+
     Ok(token_data.claims)
 }
 
 // Function to check if token needs refresh (if it's close to expiring)
 pub fn needs_refresh(token: &str) -> Result<bool> {
     let claims = validate_jwt(token)?;
-    
+
     // Get current time
     let now = get_current_timestamp();
-    
+
     // If token is more than 45 minutes old (75% of its lifetime), it needs refresh
     Ok(claims.exp - now < 900) // 900 = 15 minutes left before expiration
 }


### PR DESCRIPTION
Add a new component in client and new handler in the server, along with a new module `dashboard_icons.rs`.

`dashboard_icons.rs` fetches a `metadata.json` file from the dashboard icon's github and caches it for 1 hour.

The component allows the user to enter a search query, which is sent to the server, the server handler calls `dashboard_icons.rs` which parses the JSON and builds the icon URL, then returns an array of found icons (limit of 20) back to the client.

Icons, when selected, are saved on the link.